### PR TITLE
Support Databox API version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+Following guidelines of http://keepachangelog.com/
+
+## [Unreleased]
+- update to support Databox API version 3
+
+## [0.2.3] - Jan 25, 2016
+- [Databox](https://databox.com) API now uses `GET /lastpushes` for retrieval of last pushes.
+- Fixes for broken test suite
+- `.editorconfig` was added
+- [JSHint](http://jshint.com/) errors were fixed
+
+## [0.2.1] - Jul 22, 2015
+- Support for additional KPI attributes
+- Updated test suite for additional KPI attributes support
+- Updated example for additional KPI attributes
+
+[Unreleased]: https://github.com/databox/databox-js/compare/0.2.3...master
+[0.2.3]: https://github.com/databox/databox-js/compare/0.2.1...0.2.3
+[0.2.1]: https://github.com/databox/databox-js/tree/0.2.1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ client.insertAll([
         attributes: {
             'station': 'ny-main'
         }
+    },
+    {
+        key: 'js.prices.gas',
+        value: 200,
+
+        // With additional currency unit
+        unit: 'USD'
     }
 ], function(result){
     console.log(result);
@@ -71,6 +78,12 @@ client.lastPush(function (pushes) {
 
 // Retrieve several pushes
 client.lastPushes(10, function (pushes) {
+    console.log(pushes);
+});
+
+// Retrieve specific push
+var id = '14714784007cb9cd36cf46baefcd0a';
+client.getPush(id, function (pushes) {
     console.log(pushes);
 });
 

--- a/example.js
+++ b/example.js
@@ -19,6 +19,15 @@ client.push({
   value: 322
 });
 
+client.push({
+  key: 'js.prices.test.gas',
+  value: 124,
+  unit: 'USD',
+  attributes: {
+    'station': 'omv'
+  }
+});
+
 client.insertAll([
   {
     key: 'js.prices.gas',
@@ -34,7 +43,30 @@ client.insertAll([
 });
 
 client.lastPush(function (pushes) {
-  console.log("Last push was:");
-  console.log(JSON.stringify(pushes, null, 2));
+  var sha = pushes[0].response.body.id;
+
+  console.log('Last push id: ' + sha);
+  client.getPush(sha, function (onePush) {
+    console.log('#getPush response:', JSON.stringify(onePush, null, 2));
+  });
 });
 
+client.lastPushes(2, function (pushes) {
+  var sha = [];
+  for (var i in pushes) {
+    sha.push(pushes[i].response.body.id);
+  }
+
+  console.log('Last two pushes:', sha);
+  client.getPush(sha, function (multiplePushes) {
+    console.log('#getPush response:', JSON.stringify(multiplePushes, null, 2));
+  });
+});
+
+client.metrics(function (res) {
+  console.log('#metrics response', JSON.stringify(res, null, 2));
+});
+
+client.purge(function (res) {
+  console.log('#purge response', JSON.stringify(res, null, 2));
+});

--- a/lib/databox.js
+++ b/lib/databox.js
@@ -14,8 +14,9 @@ function Databox(config) {
   if (typeof(this.push_token) == "undefined")
     throw new Error("Missing push_token.");
 
-  this.config.push_host = 'https://push2new.databox.com/';
-  this.config.user_agent = util.format('Databox/%s (Node.js)', package_json.version);
+  this.config.push_host = 'https://push.databox.com/';
+  this.config.user_agent = util.format('databox-js/%s', package_json.version);
+  this.config.accept = util.format('application/vnd.databox.v%s+json', package_json.version.split('.')[0]);
 }
 
 Databox.prototype._pushJSONRequest = function (i_options, data, cb) {
@@ -27,7 +28,8 @@ Databox.prototype._pushJSONRequest = function (i_options, data, cb) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'User-Agent': this.config.user_agent
+      'User-Agent': this.config.user_agent,
+      'Accept': this.config.accept
     },
     auth: util.format("%s:%s", this.config.push_token, '')
   };
@@ -83,6 +85,10 @@ Databox.prototype._processKPI = function (kpi) {
     //TODO: If it's some kind of Date/Time instance do "casting".
   }
 
+  if (kpi.hasOwnProperty("unit") || typeof(kpi.unit) != "undefined") {
+    out.unit = kpi.unit;
+  }
+
   if (kpi.hasOwnProperty('attributes') || typeof(kpi.attributes) != "undefined") {
     for (var k in kpi.attributes)
       out[k] = kpi.attributes[k];
@@ -91,10 +97,19 @@ Databox.prototype._processKPI = function (kpi) {
   return out;
 };
 
+Databox.prototype.getPush = function (sha, cb) {
+  var path = (sha instanceof Array) ? '/lastpushes?id=' + sha.join(',') : '/lastpushes/' + sha;
+
+  return this._pushJSONRequest({
+    method: 'GET',
+    path: path
+  }, null, cb);
+};
+
 Databox.prototype.lastPushes = function (n, cb) {
   return this._pushJSONRequest({
     method: 'GET',
-    path: util.format("/lastpushes/%d", parseInt(n, 10))
+    path: util.format("/lastpushes?limit=%d", parseInt(n, 10))
   }, null, cb);
 };
 
@@ -114,6 +129,20 @@ Databox.prototype.insertAll = function (kpis, cb) {
     kpis.map(this._processKPI),
     cb
   );
+};
+
+Databox.prototype.metrics = function (cb) {
+  return this._pushJSONRequest({
+    method: 'GET',
+    path: '/metrickeys'
+  }, null, cb);
+};
+
+Databox.prototype.purge = function (cb) {
+  return this._pushJSONRequest({
+    method: 'DELETE',
+    path: '/data'
+  }, null, cb);
 };
 
 module.exports = Databox;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox",
-  "version": "0.2.3",
+  "version": "2.0.0",
   "description": "Node.js bindings for Databox - Mobile Executive Dashboard.",
   "author": {
     "name": "Oto Brglez",

--- a/test/databox.test.js
+++ b/test/databox.test.js
@@ -35,12 +35,16 @@ describe('Databox', function () {
       config = databox.config;
     });
 
-    it('Should have user_agent', function () {
-      assert(config.user_agent.match(/\d+\.\d+\.\d+/i) !== null);
+    it('Should have valid user_agent', function () {
+      assert(config.user_agent.match(/^databox\-js\/\d+\.\d+\.\d+/i) !== null);
     });
 
     it('Should have push_host', function () {
       assert(config.push_host.match(/databox/) !== null);
+    });
+
+    it('Should have valid accept', function () {
+      assert(config.accept.match(/^application\/vnd\.databox\.v\d\+json/) !== null);
     });
   });
 


### PR DESCRIPTION
Update SDK to support Databox API version 3

changes:
- [x] implement `GET /metrickeys`
- [x] update `GET /lastpushes`
- [x] implement `GET /lastpushes/{id}` to return specific push
- [x] implement `DELETE /data`
- [ ] handle new format & exceptions
