### PR TITLE
Fix error on JSON request with certain unicode chars

### DIFF
--- a/lib/databox.js
+++ b/lib/databox.js
@@ -41,6 +41,19 @@ Databox.prototype._pushJSONRequest = function (i_options, data, cb) {
   var jsonData = null;
   if (data !== null) {
     jsonData = JSON.stringify({data: data});
+    // When any of the values represented inside the Object being stringified, 
+    // contain some UNICODE characters, produces the return of the following Error: 
+    // {message : "Invalid request body - JSON parse error", type : "invalid_json"}
+    //
+    // The proposed patch, converts each string char to its (Hex) Unicode representation 
+    // An example, using a Spanish word -with a conflictive accent mark in the 'o'- :
+    // "Atención" => "\u0041\u0074\u0065\u006e\u0063\u0069\u00f3\u006e"
+    // This disambiguation prevents the unexpected error on the request sending.
+    // <-- BEGINING OF THE PATCH 
+    jsonData  = jsonData.replace(/[\u007F-\uFFFF]/g, function(chr) {
+      return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4);
+    });
+    // END OF THE PATCH -->
     options.headers['Content-Length'] = jsonData.length;
   }
 

--- a/lib/databox.js
+++ b/lib/databox.js
@@ -41,19 +41,6 @@ Databox.prototype._pushJSONRequest = function (i_options, data, cb) {
   var jsonData = null;
   if (data !== null) {
     jsonData = JSON.stringify({data: data});
-    // When any of the values represented inside the Object being stringified, 
-    // contain some UNICODE characters, produces the return of the following Error: 
-    // {message : "Invalid request body - JSON parse error", type : "invalid_json"}
-    //
-    // The proposed patch, converts each string char to its (Hex) Unicode representation 
-    // An example, using a Spanish word -with a conflictive accent mark in the 'o'- :
-    // "Atención" => "\u0041\u0074\u0065\u006e\u0063\u0069\u00f3\u006e"
-    // This disambiguation prevents the unexpected error on the request sending.
-    // <-- BEGINING OF THE PATCH 
-    jsonData  = jsonData.replace(/[\u007F-\uFFFF]/g, function(chr) {
-      return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4);
-    });
-    // END OF THE PATCH -->
     options.headers['Content-Length'] = jsonData.length;
   }
 
@@ -104,7 +91,21 @@ Databox.prototype._processKPI = function (kpi) {
 
   if (kpi.hasOwnProperty('attributes') || typeof(kpi.attributes) != "undefined") {
     for (var k in kpi.attributes)
-      out[k] = kpi.attributes[k];
+      // When the attribute value contain any extended UNICODE character,
+      // produces the return of the following server Error:   
+      // {message : "Invalid request body - JSON parse error", type : "invalid_json"}
+      //
+      // The proposed patch, converts each string char to its (Hex) explicit Unicode 
+      // representation. An example transformation, using a Spanish char with acent: 
+      // "ó" => "\u00f3"
+      // This disambiguation prevents the unexpected error on the server side.
+      // Original Code Line to Patch:
+      // out[k] = kpi.attributes[k];
+      // <-- BEGINING OF THE PATCH 
+      out[k] =  String( kpi.attributes[k]).replace(/[\u007F-\uFFFF]/g, function(chr) {
+        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4);
+      });
+      // END OF THE PATCH -->
   }
 
   return out;


### PR DESCRIPTION
When any of the values represented inside the Object being stringified, contain some UNICODE characters, produces the return of the following Error: 
{message : "Invalid request body - JSON parse error", type : "invalid_json"}

The proposed patch, converts each string char to its (Hex) Unicode representation  
An example, using a Spanish word -with a conflictive accent mark in the 'o'- :
"Atención" => "\u0041\u0074\u0065\u006e\u0063\u0069\u00f3\u006e"
The proposed disambiguation prevents the unexpected error on the request sending.

(addition in line 44 of databox.js)
    jsonData  = jsonData.replace(/[\u007F-\uFFFF]/g, function(chr) {
      return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4);
    });