### PR TITLE
fix(ci): try upgrading from travisci to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+
+jobs:
+  test:
+    docker:
+      - image: circleci/node:11.10.1
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Install NPM Packages
+          command: |
+            npm install
+      - run:
+          name: Unit Tests
+          command: |
+            npm test
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+
+workflows:
+  version: 2
+  test_databox:
+    jobs:
+      - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "0.12"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # databox-js
 
-[![Build Status](https://travis-ci.org/databox/databox-js.svg)](https://travis-ci.org/databox/databox-js)
+![seanforyou23](https://circleci.com/gh/seanforyou23/databox-js.svg?style=shield)
+
 [![npm version](https://badge.fury.io/js/databox.svg)](https://badge.fury.io/js/databox)
 
 ## Installation


### PR DESCRIPTION
Hello! I noticed the CI job was busted and wanted to try and help. TravisCI seems to be losing traction in the community and with the current configuration not working, I thought it may be a good time to upgrade to something else. I've removed the config for travis and added one for circleci which can be easily extended to do other types of checks if you need. I'm using the badge for my personal circleci account, if you guys can set up an account I'd be happy to update it to point to the badge under the org, until then it would just read "no builds". You can check it with [this link](https://circleci.com/gh/databox/databox-js.svg?style=shield).

Anyway, this should close https://github.com/databox/databox-js/issues/9 and take the build from failing

<img width="200" alt="Screen Shot 2020-09-17 at 11 36 43 AM" src="https://user-images.githubusercontent.com/5942899/93493634-1fe6cd80-f8da-11ea-8aff-f8efa151f340.png">

 to passing

<img width="200" alt="Screen Shot 2020-09-17 at 11 36 33 AM" src="https://user-images.githubusercontent.com/5942899/93493647-26754500-f8da-11ea-80d3-f0649a6240ca.png">

Here's a couple more screengrabs of what the new dashboard would look like.

<img width="600" alt="Screen Shot 2020-09-17 at 11 22 07 AM" src="https://user-images.githubusercontent.com/5942899/93493479-f0d05c00-f8d9-11ea-8db8-b95e3b772d53.png">

<img width="400" alt="Screen Shot 2020-09-17 at 11 22 40 AM" src="https://user-images.githubusercontent.com/5942899/93493481-f0d05c00-f8d9-11ea-9ec3-fa5c136dae89.png">

I hope it helps, please let me know if you have any questions!
 