### PR TITLE
Add license metadata to package manifest

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,7 @@
 {
   "name": "databox",
   "version": "2.1.2",
+    "license": "MIT",
   "description": "OpenAPI client for databox",
   "author": "OpenAPI-Generator",
   "repository": {


### PR DESCRIPTION
Summary
Adds MIT license metadata to src/package.json, matching the repository LICENSE file and making the published npm metadata clearer.

Verification
Checked npm metadata for databox 2.1.2 has no license field.
Confirmed repository LICENSE is MIT.
Parsed the edited src/package.json and verified license is MIT.

Tests not run; metadata-only change.